### PR TITLE
Throw exception if file not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+pom.xml
+*jar
+lib
+classes
+.cake
+*#*
+*~
+semantic.cache

--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -82,8 +82,10 @@
   (seq nodes))
 
 (defmethod get-resource String
- [path loader]
-  (-> (clojure.lang.RT/baseLoader) (.getResourceAsStream path) loader))
+  [path loader]  
+  (if-let [resource (.getResourceAsStream (clojure.lang.RT/baseLoader) path)]
+    (loader resource)
+    (throw (IllegalArgumentException. (str "Cannot find " path)))))
 
 (defmethod get-resource java.io.File
  [^java.io.File file loader]

--- a/test/net/cgrand/enlive_html/test.clj
+++ b/test/net/cgrand/enlive_html/test.clj
@@ -265,3 +265,22 @@
   (is-same "<div><div class='bar'><div>"
     (sniptest "<div><div><div>"
       [:> :div] (transform-content [:> :div] (add-class "bar")))))
+
+
+(deftest process-existing-html  
+  (let [existing-template (deftemplate
+                            existing-template
+                            "net/cgrand/enlive_html/fixture.html"
+                            [some-arg]
+                            [:div] (content "CHANGED!"))]
+    (is (= 
+         '("<html>" "<head><title>This is a test.</title></head>" "<body>" "<div class=\"some-class\" id=\"some-div\">" "CHANGED!" "</div>" "</body>" "\n" "</html>")
+         (existing-template :blah)))))
+
+(deftest complain-when-html-does-not-exist
+  ( is (thrown? IllegalArgumentException
+                (deftemplate template-with-incorrect-html
+                  "template/that/is/not/really/there.html"
+                  [blah blah]
+                  [[:sometag (attr? :something)]]))))
+


### PR DESCRIPTION
Hi there,

Two small changes:
- A .gitignore file excluding basic stuff
- If we can't find the HTML template it used to throw a NPE. Changed to an IllegalArgumentException with a more descriptive message

Cheers and keep up the awesome work!
