### PR TITLE
Remove duplicate definition of `transform-node`

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -467,12 +467,6 @@
     :else ;fragment
       (transform-fragment nodes selector transformation)))
 
-(defn- transform-node [nodes selector transformation]
-  (let [transformation (or transformation (constantly nil))
-        transformations (constantly transformation)  
-        state (automaton selector)]
-    (mapknit #(transform-loc (xml/xml-zip %1) state transformations %2) nodes)))
-
 (defn lockstep-transform [nodes transformations-map]
   (let [state (lockstep-automaton (keys transformations-map))
         transformations (vec (map #(or % (constantly nil)) 


### PR DESCRIPTION
Hello,

I was reading through enlive source today and noticed that `transform-node` is defined at line 419 and again at line 470. This pull request removes the version at line 470.

Thanks for Enlive!

Kevin N.
