### PR TITLE
Fixed bug: Using the attr|= selector failed if the value of the attribute was equal to the test value

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -756,7 +756,7 @@
 (defn- is-first-segment? [^String s ^String segment]
   (and s 
     (.startsWith s segment)
-    (= \- (.charAt s (count segment)))))
+    (or (= (count s) (count segment)) (= \- (.charAt s (count segment))))))
              
 (def ^{:doc "Selector predicate, tests if the specified attributes start with the specified values. See CSS |= ."}
  attr|=           

--- a/test/net/cgrand/enlive_html/test.clj
+++ b/test/net/cgrand/enlive_html/test.clj
@@ -66,6 +66,13 @@
     false (attr= :href "http://cgrand.net/" :title "homepage")
     true (attr= :href "http://cgrand.net/" :title "home")))
 
+(deftest attr|=-test
+  (are [_1 _2] (test-step _1 _2 (elt :a {:href "http://cgrand.net/" :hreflang "de" :hreflang2 "en-en"}))
+    false (attr|= :hreflang "en")
+    true (attr|= :hreflang "de")
+    false (attr|= :hreflang2 "fr")
+    true (attr|= :hreflang2 "en")))
+
 (deftest attr-starts-test
   (are [_1 _2] (test-step _1 _2 (elt :a {:href "http://cgrand.net/" :title "home"}))
     true (attr-starts :href "http://cgr")


### PR DESCRIPTION
Hello Christophe,

I recently played with enlive. I believe I found a bug, and hopefully I fixed it.

I used the "attr|=" selector, and it failed with an "java.lang.StringIndexOutOfBoundsException: String index out of range" if the value of the tested attribute was equal to the comparison value.

The W3C documentation says about the "attr|=" selector:

'Represents an element with the att attribute, its value either being exactly "val" or beginning with "val" immediately followed by "-" (U+002D).'

Please review the test case and the fix, and merge it if it is appropriate.

Best Regards
Stephan Mühlstrasser
