### PR TITLE
Add JSoup as a parsing backend

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,5 @@
   :url "http://github.com/cgrand/enlive/"
   :profiles     {:dev {:resource-paths ["test/resources"]}}
   :dependencies [[org.clojure/clojure "1.2.0"]
-                 [org.ccil.cowan.tagsoup/tagsoup "1.2.1"]])
+                 [org.ccil.cowan.tagsoup/tagsoup "1.2.1"]
+                 [org.jsoup/jsoup "1.7.2"]])

--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -10,6 +10,7 @@
 
 (ns net.cgrand.enlive-html
   "enlive-html is a selector-based transformation and extraction engine."
+  (:require [net.cgrand.jsoup :as jsoup])
   (:require [net.cgrand.xml :as xml])
   (:require [clojure.string :as str])
   (:require [clojure.zip :as z]))
@@ -67,6 +68,12 @@
  [stream] 
   (with-open [^java.io.Closeable stream stream]
     (xml/parse (org.xml.sax.InputSource. stream))))
+
+(defn jsoup-parser
+  "Parse a HTML document stream into Enlive nodes using JSoup."
+  [stream]
+  (with-open [^java.io.Closeable stream stream]
+    (jsoup/parse stream)))
 
 (defmulti ^{:arglists '([resource loader])} get-resource 
  "Loads a resource, using the specified loader. Returns a seq of nodes." 

--- a/src/net/cgrand/jsoup.clj
+++ b/src/net/cgrand/jsoup.clj
@@ -1,0 +1,58 @@
+;   Copyright (c) Christophe Grand, 2009. All rights reserved.
+;   Copyright (c) Baishampayan Ghose, 2013. All rights reserved.
+
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this
+;   distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(ns net.cgrand.jsoup
+  "JSoup based parser backend."
+  (:import [org.jsoup Jsoup]
+           [org.jsoup.nodes Attribute Attributes Comment DataNode Document
+            DocumentType Element Node TextNode XmlDeclaration]
+           [org.jsoup.parser Parser Tag]))
+
+(def ^:private ->key (comp keyword #(.. % toString toLowerCase)))
+
+(defprotocol IEnlive
+  (->nodes [d] "Convert object into Enlive node(s)."))
+
+(extend-protocol IEnlive
+  Attribute
+  (->nodes [a] [(->key (.getKey a)) (.getValue a)])
+
+  Attributes
+  (->nodes [as] (not-empty (into {} (map ->nodes as))))
+
+  Comment
+  (->nodes [c] {:type :comment :data (.getData c)})
+
+  DataNode
+  (->nodes [dn] (str dn))
+
+  Document
+  (->nodes [d] (not-empty (map ->nodes (.childNodes d))))
+
+  DocumentType
+  (->nodes [dtd] {:type :dtd :data ((juxt :name :publicid :systemid) (->nodes (.attributes dtd)))})
+
+  Element
+  (->nodes [e] {:tag (->key (.tagName e))
+                :attrs (->nodes (.attributes e))
+                :content (not-empty (map ->nodes (.childNodes e)))})
+
+  TextNode
+  (->nodes [tn] (.getWholeText tn))
+
+  nil
+  (->nodes [_] nil))
+
+
+(defn parse
+  "Parse a document into nodes using JSoup"
+  [s]
+  (->nodes (Jsoup/parse s "UTF-8" "")))


### PR DESCRIPTION
For now, I have added JSoup as a dependency. Looking for better ideas.

All tests pass if you do `(set-ns-parser! jsoup-parser)` in the test file. Still need to find a good way to test all the parsing backends.

Suggestions welcome!
