### PR TITLE
Restructure the JSoup backend a little bit

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -40,12 +40,12 @@ or globally *for the declaring ns*:
 (set-ns-parser! xml-parser)
 </pre>
 
-A parser is a function from InputStream to nodes. tagsoup-parser and xml-parser are the two builtin ones.
+A parser is a function from InputStream to nodes. xml-parser, @net.cgrand.tagsoup/parser@ and @net.cgrand.jsoup/parser@ are the three builtin ones.
 
 h3. @${vars}@ substitutions (1.1.1)
 
 The following selector + function is going to replace any @${var}@ in text *and attributes* by the value found in the map (or any function).
- 
+
 <pre>
 [:#container any-node] (replace-vars {:name "world" :class "hello"})
 </pre>

--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -11,7 +11,6 @@
 (ns net.cgrand.enlive-html
   "enlive-html is a selector-based transformation and extraction engine."
   (:require [net.cgrand.tagsoup :as tagsoup])
-  (:require [net.cgrand.jsoup :as jsoup])
   (:require [net.cgrand.xml :as xml])
   (:require [clojure.string :as str])
   (:require [clojure.zip :as z]))
@@ -69,12 +68,6 @@
  [stream] 
   (with-open [^java.io.Closeable stream stream]
     (xml/parse (org.xml.sax.InputSource. stream))))
-
-(defn jsoup-parser
-  "Parse a HTML document stream into Enlive nodes using JSoup."
-  [stream]
-  (with-open [^java.io.Closeable stream stream]
-    (jsoup/parse stream)))
 
 (defmulti ^{:arglists '([resource loader])} get-resource 
  "Loads a resource, using the specified loader. Returns a seq of nodes." 

--- a/src/net/cgrand/jsoup.clj
+++ b/src/net/cgrand/jsoup.clj
@@ -52,7 +52,8 @@
   (->nodes [_] nil))
 
 
-(defn parse
-  "Parse a document into nodes using JSoup"
-  [s]
-  (->nodes (Jsoup/parse s "UTF-8" "")))
+(defn parser
+  "Parse a HTML document stream into Enlive nodes using JSoup."
+  [stream]
+  (with-open [^java.io.Closeable stream stream]
+    (->nodes (Jsoup/parse stream "UTF-8" ""))))


### PR DESCRIPTION
- Move the Jsoup parser fn into the JSoup ns for consistency.
- Mention the parsers in API docs.
