### PR TITLE
Fix #6 - Auto-reloading of templates / snippets support

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -581,7 +581,7 @@
   "Get the last modified date for the given classpath resource."
   [res]
   (-> (clojure.lang.RT/baseLoader) (.getResource res)
-      (.toURI) (java.io.File.) (.lastModified)))
+      (.openConnection) (.getLastModified)))
 
 (defn html-resource*
   "Parse an html resource and include metadata."


### PR DESCRIPTION
This adds opt-in support for auto-reloading of templates and snippets. The template and snippet nodes are cached. When the html resource has been modified the cached nodes are updated. Below is an example of how to opt-in:

``` clojure
(ns myapp.views.example
  (:require [net.cgrand.enlive-html :as html]))

(html/alter-ns-options! assoc :reloadable? true)

(html/deftemplate layout "templates/example.html" []
  [:h1] (content "Hello world!"))
```

For my testing I used the following method:

``` clojure
(html/alter-ns-options! assoc :reloadable?
  (= (System/getenv "MODE") "dev"))
```

Which enables the auto-reload feature while in development mode only.
