### PR TITLE
support mixed hiccup/node representations in `html`

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -997,6 +997,7 @@
                    node)]
         node)
     (sequential? node-spec) (flatmap nodify node-spec)
+    (map? node-spec) (update-in node-spec [:content] (comp nodify seq))
     :else (str node-spec)))
 
 (defn html

--- a/test/net/cgrand/enlive_html/test.clj
+++ b/test/net/cgrand/enlive_html/test.clj
@@ -290,6 +290,15 @@
     (sniptest "<div>"
       [:div] (content (html [:ul (for [s ["a" "b" "c"]] [:li s])])))))
 
+(deftest hiccup-mixed
+  (is-same "<div><p><i>big</i><b>world</b></p>"
+    (sniptest "<div>"
+      [:div] (content (html [:p '({:tag :i :content ["big"]}
+                                  {:tag :b :content ["world"]})])))
+    (sniptest "<div>"
+      [:div] (content (html {:tag :p
+                             :content [[:i "big"] [:b "world"]]})))))
+
 (deftest replace-vars-test
   (is-same "<div><h1>untouched ${name}<p class=hello>hello world"
            (sniptest "<div><h1>untouched ${name}<p class=\"${class}\">hello ${name}"


### PR DESCRIPTION
Currently, `html` only works with "pure-hiccup" representations, so there's no way to e.g. drop a snippet or other seq of nodes into bits of hiccup-style data.

This patch allows mixed hiccup/node representations to be passed to `html` so that it only needs to be used once per e.g. transformation.
