### PR TITLE
Correct a unit test and location of 2 doc strings

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -644,9 +644,10 @@
     (fn [elt#]
       (assoc elt# :content (flatmap f# (:content elt#))))))
 
-(defn html-snippet [& values]
+(defn html-snippet
  "Concatenate values as a string and then parse it with tagsoup.
   html-snippet doesn't insert missing <html> or <body> tags."
+ [& values]
   (-> (apply str "<bogon>" values)
     java.io.StringReader. html-resource first :content))
 
@@ -681,10 +682,11 @@
                                        [k (substitute-vars v)])))
           :else node)))))
 
-(defn replace-words [words-to-replacements]
+(defn replace-words
   "Takes a map of words to replacement strings and replaces 
    all occurences. Does not recurse, you have to pair it with an appropriate
    selector."
+ [words-to-replacements] 
   (replace-vars
     (java.util.regex.Pattern/compile (str "\\b(" (str/join "|" (map #(java.util.regex.Pattern/quote %) (keys words-to-replacements))) ")\\b")) 
     words-to-replacements

--- a/test/net/cgrand/enlive_html/test.clj
+++ b/test/net/cgrand/enlive_html/test.clj
@@ -273,7 +273,7 @@
   (.startsWith "<!DOCTYPE" (apply str (case-insensitive-doctype-template))))
 
 (deftest templates-return-seqs
-  (seq? (case-insensitive-doctype-template)))
+  (is (seq? (case-insensitive-doctype-template))))
 
 (deftest hiccup-like
   (is-same "<div><b>world"


### PR DESCRIPTION
At least, I hope it is a correction to the unit test.

Found using a pre-release version of the Eastwood Clojure lint tool.

It also found a deprecated Java method.  At least, it is deprecated in JDK 7 -- I am not sure what range of JDK versions you support with enlive:

== Linting net.cgrand.enlive-html ==
{:linter :deprecations,
 :msg
 "Instance method 'public java.net.URL java.io.File.toURL() throws java.net.MalformedURLException' is deprecated.",
 :line 98}
