### PR TITLE
Convert `replace-vars` args into strings

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -671,7 +671,7 @@
   ([m] (replace-vars #"\$\{\s*([^}]*[^\s}])\s*}" m))
   ([re m] (replace-vars re m keyword))
   ([re m f]
-    (let [replacement (comp m f second)
+    (let [replacement (comp str m f second)
           substitute-vars #(str/replace % re replacement)]
       (fn [node]
         (cond

--- a/test/net/cgrand/enlive_html/test.clj
+++ b/test/net/cgrand/enlive_html/test.clj
@@ -312,5 +312,7 @@
       #{[:p] [:p any-node]} (replace-vars {:name "world" :class "hello"})))
   (is (= ((replace-vars {:a "A" :b "B"}) "${a} ${b}")
         "A B"))
+  (is (= ((replace-vars {:a "A" :b 42}) "${a} ${b}")
+         "A 42"))
   (is (= ((replace-words {"Donald" "Mickey" "Duck" "Mouse"}) "Donald Duckling Duck")
         "Mickey Duckling Mouse")))


### PR DESCRIPTION
Prior to this commit, trying to substitute a number via `replace-vars`
would throw an exception, because the replacement value is not a
string.  Example:

```
((replace-vars {:a 42}) "#{a}")
;; throws ClassCastException in clojure.string/replace-by
```

This commit makes it so that any substitute is converted into its
string representation via `str` before substitution.  For example, 42
is converted into "42" so it can be substituted properly.  This
fixes the issue and allows any `str`-able value to substitute in.
