### PR TITLE
Fixed a typo in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ text __and attributes__ by the value found in the map (or any function).
 ### hiccup-style helper (1.1.0)
 
 ```clj
-(content (html [:h3#hello "Hello worls"]))
+(content (html [:h3#hello "Hello world"]))
 ```
 
 ### older stuff

--- a/README.textile
+++ b/README.textile
@@ -72,7 +72,7 @@ The following selector + function is going to replace any @${var}@ in text *and 
 h3. hiccup-style helper (1.1.0)
 
 <pre>
-(content (html [:h3#hello "Hello worls"]))
+(content (html [:h3#hello "Hello world"]))
 </pre>
 
 


### PR DESCRIPTION
One of the examples contained "hello worls" instead of "hello world"
