### PR TITLE
Clojure 1.7 compatibility fix

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -10,6 +10,7 @@
 
 (ns net.cgrand.enlive-html
   "enlive-html is a selector-based transformation and extraction engine."
+  (:refer-clojure :exclude [flatmap])
   (:require [net.cgrand.tagsoup :as tagsoup])
   (:require [net.cgrand.xml :as xml])
   (:require [clojure.string :as str])


### PR DESCRIPTION
Clojure 1.7.0 adds 'flatmap' into clojure.core as part of the
transducers API.
