### PR TITLE
make reload work on windows

### DIFF
--- a/src/net/cgrand/reload.clj
+++ b/src/net/cgrand/reload.clj
@@ -47,7 +47,6 @@
 (def ^:private no-strings (into-array String nil))
 
 (defmethod watch-url "file" [^java.net.URL url ns]
-  (let [fs (java.nio.file.FileSystems/getDefault)
-        path (.getPath fs (.getPath url) no-strings)
+  (let [path (java.nio.file.Paths/get (.toURI url))
         ws (watch-service ns)]
     (ws path)))


### PR DESCRIPTION
in 1.1.5 reload fails on windows with

```
InvalidPathException Illegal char <:> at index 2: /c:/somepath/index.html  sun.nio.fs.WindowsPathParser.normalize (WindowsPathParser.java:182)
```

This pull request should fix the problem. I've also tested this on a Mac an it appears to work.
