### PR TITLE
tweak function text

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -952,6 +952,7 @@
  [node]
   (cond
     (string? node) node
+    (= :br (:tag node)) "\n"
     (xml/tag? node) (apply str (map text (:content node)))
     :else ""))
 


### PR DESCRIPTION
Couldn't it be more convenient if `<br />` tag be transformed into `"\n"` when applied function `enlive-html/text`?