### PR TITLE
Fix "Illegal Reflection" warning for Clojure 1.10 & Java 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,14 +2,17 @@
   :description "a HTML selector-based (à la CSS) templating and transformation system for Clojure"
   :url "http://github.com/cgrand/enlive/"
   :min-lein-version "2.7.1"
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.ccil.cowan.tagsoup/tagsoup "1.2.1"]
-                 [org.jsoup/jsoup "1.7.2"]
+                 [org.jsoup/jsoup "1.11.3"]
                  [tupelo "0.9.133"]]
 
-  :profiles {:dev {:resource-paths ["test/resources"]}}
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]]}
+             :dev      {:dependencies [[org.clojure/clojure "1.10.0"]]}
+             :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}}
 
   :source-paths ["src"]
   :test-paths ["test"]
+  :resource-paths ["test/resources"]
   :target-path "target/%s"
   )

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,10 @@
-(defproject enlive "1.1.6"
+(defproject enlive "1.1.7"
   :description "a HTML selector-based (à la CSS) templating and transformation system for Clojure"
   :url "http://github.com/cgrand/enlive/"
   :min-lein-version "2.7.1"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.ccil.cowan.tagsoup/tagsoup "1.2.1"]
-                 [org.jsoup/jsoup "1.11.3"]
-                 [tupelo "0.9.133"]]
+                 [org.jsoup/jsoup "1.11.3"]]
 
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]]}
              :dev      {:dependencies [[org.clojure/clojure "1.10.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,15 @@
 (defproject enlive "1.1.6"
-  :min-lein-version "2.0.0"
   :description "a HTML selector-based (à la CSS) templating and transformation system for Clojure"
   :url "http://github.com/cgrand/enlive/"
-  :profiles     {:dev {:resource-paths ["test/resources"]}}
-  :dependencies [[org.clojure/clojure "1.2.0"]
+  :min-lein-version "2.7.1"
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.ccil.cowan.tagsoup/tagsoup "1.2.1"]
-                 [org.jsoup/jsoup "1.7.2"]])
+                 [org.jsoup/jsoup "1.7.2"]
+                 [tupelo "0.9.133"]]
+
+  :profiles {:dev {:resource-paths ["test/resources"]}}
+
+  :source-paths ["src"]
+  :test-paths ["test"]
+  :target-path "target/%s"
+  )

--- a/src/net/cgrand/xml.clj
+++ b/src/net/cgrand/xml.clj
@@ -102,15 +102,3 @@
       (startparse s content-handler)
       (map #(if (instance? clojure.lang.IObj %) (vary-meta % merge @metadata) %)
         (-> @loc z/root :content)))))
-         
-
-
-
-
-
-
-
-
-
-
-

--- a/src/net/cgrand/xml.clj
+++ b/src/net/cgrand/xml.clj
@@ -8,9 +8,9 @@
 
 (ns net.cgrand.xml
   (:require [clojure.zip :as z])
-  (:import (org.xml.sax ContentHandler Attributes SAXException XMLReader)
+  (:import (org.xml.sax Attributes )
            (org.xml.sax.ext DefaultHandler2)
-           (javax.xml.parsers SAXParser SAXParserFactory)))
+           (javax.xml.parsers SAXParserFactory)))
 
 (defstruct element :tag :attrs :content)
 
@@ -82,7 +82,10 @@
    .newSAXParser
    (doto
      (.setProperty "http://xml.org/sax/properties/lexical-handler" ch))
-   (.parse s ch)))
+   (.parse
+     ^java.io.InputStream s                   ; actual type => java.io.BufferedInputStream
+     ^org.xml.sax.helpers.DefaultHandler ch   ; actual type => net.cgrand.xml.proxy$org.xml.sax.ext.DefaultHandler2
+   )))
 
 (defn parse
   "Parses and loads the source s, which can be a File, InputStream or
@@ -100,3 +103,14 @@
       (map #(if (instance? clojure.lang.IObj %) (vary-meta % merge @metadata) %)
         (-> @loc z/root :content)))))
          
+
+
+
+
+
+
+
+
+
+
+

--- a/src/net/cgrand/xml.clj
+++ b/src/net/cgrand/xml.clj
@@ -83,7 +83,7 @@
    (doto
      (.setProperty "http://xml.org/sax/properties/lexical-handler" ch))
    (.parse
-     ^java.io.InputStream s                   ; actual type => java.io.BufferedInputStream
+     ^java.io.InputStream                s    ; actual type => java.io.BufferedInputStream
      ^org.xml.sax.helpers.DefaultHandler ch   ; actual type => net.cgrand.xml.proxy$org.xml.sax.ext.DefaultHandler2
    )))
 

--- a/test/tst/net/cgrand/xml.clj
+++ b/test/tst/net/cgrand/xml.clj
@@ -1,13 +1,11 @@
 (ns tst.net.cgrand.xml
-  (:use tupelo.core tupelo.test)
+  (:use clojure.test)
   (:require
-    [net.cgrand.xml :as xml]
-    [tupelo.string :as ts]
-  ))
+    [clojure.java.io :as io]
+    [net.cgrand.xml :as xml] ))
 
-
-(dotest
-  (let [xml-str "<foo>
+(deftest t-xml-7
+  (let [xml-str  "<foo>
                     <name>John</name>
                     <address>1 hacker way</address>
                     <phone></phone>
@@ -23,9 +21,38 @@
                     </college>
                   </foo> "
 
-        xml-data (xml/parse (ts/string->stream xml-str))
-        ]
-    (spyx-pretty xml-data)
-
-    ))
+        xml-data (xml/parse (io/input-stream (.getBytes xml-str))) ]
+    (is (= xml-data
+          [{:tag   :foo,
+            :attrs nil,
+            :content
+             [ "\n                    "
+              {:tag :name, :attrs nil, :content ["John"]}
+              "\n                    "
+              {:tag :address, :attrs nil, :content ["1 hacker way"]}
+              "\n                    "
+              {:tag :phone, :attrs nil, :content nil}
+              "\n                    "
+              {:tag   :school,
+               :attrs nil,
+               :content
+                ["\n                        "
+                 {:tag :name, :attrs nil, :content ["Joe"]}
+                 "\n                        "
+                 {:tag :state, :attrs nil, :content ["CA"]}
+                 "\n                        "
+                 {:tag :type, :attrs nil, :content ["FOOBAR"]}
+                 "\n                    "]}
+              "\n                    "
+              {:tag   :college,
+               :attrs nil,
+               :content
+                ["\n                        "
+                 {:tag :name, :attrs nil, :content ["mit"]}
+                 "\n                        "
+                 {:tag :address, :attrs nil, :content nil}
+                 "\n                        "
+                 {:tag :state, :attrs nil, :content ["Denial"]}
+                 "\n                    "]}
+              "\n                  "]}])) ))
 

--- a/test/tst/net/cgrand/xml.clj
+++ b/test/tst/net/cgrand/xml.clj
@@ -1,0 +1,31 @@
+(ns tst.net.cgrand.xml
+  (:use tupelo.core tupelo.test)
+  (:require
+    [net.cgrand.xml :as xml]
+    [tupelo.string :as ts]
+  ))
+
+
+(dotest
+  (let [xml-str "<foo>
+                    <name>John</name>
+                    <address>1 hacker way</address>
+                    <phone></phone>
+                    <school>
+                        <name>Joe</name>
+                        <state>CA</state>
+                        <type>FOOBAR</type>
+                    </school>
+                    <college>
+                        <name>mit</name>
+                        <address></address>
+                        <state>Denial</state>
+                    </college>
+                  </foo> "
+
+        xml-data (xml/parse (ts/string->stream xml-str))
+        ]
+    (spyx-pretty xml-data)
+
+    ))
+


### PR DESCRIPTION
Upgrading from Clojure 1.9 to 1.10, I am getting a new warning:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by clojure.lang.InjectedInvoker/0x0000000800231c40 (file:/home/alan/.m2/repository/org/clojure/clojure/1.10.0/clojure-1.10.0.jar) to method com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(org.xml.sax.InputSource,org.xml.sax.HandlerBase)
WARNING: Please consider reporting this to the maintainers of clojure.lang.InjectedInvoker/0x0000000800231c40
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Using Java 11 on Ubuntu 16.04.   

This can be fixed by type hints on the `net.cgrand.xml/startparse-sax` method.  I also upgraded the `project.clj` to current versions of `lein` and `jsoup`. Tests are clean:

```
~/gh/enlive > lein clean ; lein test

lein test net.cgrand.enlive-html.test

lein test tst.net.cgrand.xml

Ran 31 tests containing 105 assertions.
0 failures, 0 errors.

~/gh/enlive > java --version ; lein --version
java 11 2018-09-25
Java(TM) SE Runtime Environment 18.9 (build 11+28)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11+28, mixed mode)

Leiningen 2.9.0 on Java 11 Java HotSpot(TM) 64-Bit Server VM
```
