### PR TITLE
More specific exception

### DIFF
--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -106,7 +106,7 @@
  [stream loader]
   (loader stream))
 
-(defmethod register-resource! java.net.URL 
+(defmethod register-resource! java.net.URL
   [^java.net.URL url]
   (alter-meta! *ns* update-in [:net.cgrand.reload/deps] (fnil conj #{}) url))
 
@@ -142,7 +142,7 @@
   ([t a b c d e] (-> t (conj! a) (conj! b) (conj! c) (conj! d) (conj! e)))
   ([t a b c d e f] (-> t (conj! a) (conj! b) (conj! c) (conj! d) (conj! e) (conj! f)))
   ([t a b c d e f g] (-> t (conj! a) (conj! b) (conj! c) (conj! d) (conj! e) (conj! f) (conj! g)))
-  ([t a b c d e f g & more] 
+  ([t a b c d e f g & more]
     (reduce conj! (-> t (conj! a) (conj! b) (conj! c) (conj! d) (conj! e) (conj! f) (conj! g))
       more)))
 
@@ -684,12 +684,12 @@
           :else node)))))
 
 (defn replace-words
-  "Takes a map of words to replacement strings and replaces 
+  "Takes a map of words to replacement strings and replaces
    all occurences. Does not recurse, you have to pair it with an appropriate
    selector."
- [words-to-replacements] 
+ [words-to-replacements]
   (replace-vars
-    (java.util.regex.Pattern/compile (str "\\b(" (str/join "|" (map #(java.util.regex.Pattern/quote %) (keys words-to-replacements))) ")\\b")) 
+    (java.util.regex.Pattern/compile (str "\\b(" (str/join "|" (map #(java.util.regex.Pattern/quote %) (keys words-to-replacements))) ")\\b"))
     words-to-replacements
     identity))
 

--- a/src/net/cgrand/enlive_html.clj
+++ b/src/net/cgrand/enlive_html.clj
@@ -10,6 +10,7 @@
 
 (ns net.cgrand.enlive-html
   "enlive-html is a selector-based transformation and extraction engine."
+  (:import java.util.MissingResourceException)
   (:refer-clojure :exclude [flatmap])
   (:require [net.cgrand.tagsoup :as tagsoup])
   (:require [net.cgrand.xml :as xml])
@@ -86,7 +87,9 @@
 
 (defmethod get-resource String
  [path loader]
-  (-> (clojure.lang.RT/baseLoader) (.getResourceAsStream path) loader))
+  (if-let [resource-stream (-> (clojure.lang.RT/baseLoader) (.getResourceAsStream path))]
+    (loader resource-stream)
+    (throw (java.util.MissingResourceException. "HTML Resource not found (Hint: it might be missing from CLASSPATH)" "java.io.InputStream" path))))
 
 (defmethod register-resource! String [path]
   (register-resource! (.getResource (clojure.lang.RT/baseLoader) path)))


### PR DESCRIPTION
The Quickstart proved misleading (https://github.com/cgrand/enlive/issues/154) and didn't adequately signal that the word resource meant a *Java resource*. It looks a lot like a file path.

This PR improves the exception thrown from `NullPointerException` to `MissingResourceException` and adds a hint to the error message with more context. 

it assumes that people are more likely to run into this failure mode when they follow the Quickstart int he README.